### PR TITLE
Increase validation pitch limit

### DIFF
--- a/characteristics.py
+++ b/characteristics.py
@@ -34,8 +34,8 @@ psmc_power = ((0, 0, 0, 15.0),
 
 # validation limits
 # 'msid' : (( quantile, absolute max value ))
-validation_limits = { 'DP_PITCH' : ((1, 4.0),
-                                    (99, 4.0),
+validation_limits = { 'DP_PITCH' : ((1, 4.5),
+                                    (99, 4.5),
                                     (5, 1.5),
                                     (95, 1.5),),
                       'POINTING': ((1, .05),


### PR DESCRIPTION
Increase 1 and 99th quantile pitch limits from 4.0 to 4.1.   Pitch validation on 2016:333 is showing a -4.076 1% quantile. 