### PR TITLE
Get rid of DP_PITCH warnings on 4.6 deg offsets

### DIFF
--- a/characteristics.py
+++ b/characteristics.py
@@ -1,4 +1,4 @@
-VERSION = 11
+VERSION = 12
 
 # PSMC average power for each state (fep_count, vid_board, clocking)
 # [fep_count, vid_board, clocking, power_avg]

--- a/characteristics.py
+++ b/characteristics.py
@@ -34,8 +34,9 @@ psmc_power = ((0, 0, 0, 15.0),
 
 # validation limits
 # 'msid' : (( quantile, absolute max value ))
-validation_limits = { 'DP_PITCH' : ((1, 4.5),
-                                    (99, 4.5),
+# Note that the quantile needs to be in the set (1, 5, 16, 50, 84, 95, 99)
+validation_limits = { 'DP_PITCH' : ((1, 5.0),
+                                    (99, 5.0),
                                     (5, 1.5),
                                     (95, 1.5),),
                       'POINTING': ((1, .05),


### PR DESCRIPTION
Get rid of DP_PITCH warnings on 4.6 deg offsets. 

Increase DP_PITCH limit to 5.0 deg.