### PR TITLE
Add sqlite checks

### DIFF
--- a/run_daily_state_check.py
+++ b/run_daily_state_check.py
@@ -53,6 +53,11 @@ def main(opt):
     print CHECK_EXE
     os.system("%s --run_start_time %s --days %s --outdir %s"
               % (CHECK_EXE, run_time_date, opt.telem_days, day_dir))
+    sqlite_day_dir = os.path.join(day_dir, 'sqlite')
+    sqlite_db = os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')
+    os.system(
+        "%s --run_start_time %s --days %s --outdir %s --dbi sqlite --server %s"
+        % (CHECK_EXE, run_time_date, opt.telem_days, sqlite_day_dir, sqlite_db))
 
 
 if __name__ == '__main__':

--- a/validate_states.py
+++ b/validate_states.py
@@ -123,6 +123,14 @@ def get_options():
                       type='int',
                       default=1,
                       help="Verbosity (0=quiet, 1=normal, 2=debug)")
+    parser.add_option('--dbi',
+                      default='sybase')
+    parser.add_option('--server',
+                      default='sybase')
+    parser.add_option('--user',
+                      default='aca_read')
+    parser.add_option('--database',
+                      default='aca')
     parser.add_option("--version",
                       action='store_true',
                       help="Print version")
@@ -585,8 +593,8 @@ def get_states(datestart, datestop):
     :returns: np recarry of states
     """
     logger.info('Connecting to database to get cmd_states')
-    db = Ska.DBI.DBI(dbi='sybase', server='sybase',
-                     user='aca_read', database='aca')
+    db = Ska.DBI.DBI(dbi=opt.dbi, server=opt.server,
+                     user=opt.user, database=opt.database)
 
     datestart = DateTime(datestart).date
     datestop = DateTime(datestop).date


### PR DESCRIPTION
This adds support for sqlite via options to `validate_states.py` and then sets up the daily run to just run a sqlite version on the side.

The sqlite version could also be run via new options to the daily run script so that the two could be called as independent runs from the task_schedule, but that is not implemented here.