### PR TITLE
Change dp_pitch warning limits

### DIFF
--- a/characteristics.py
+++ b/characteristics.py
@@ -1,4 +1,4 @@
-VERSION = 16
+VERSION = 17
 
 # PSMC average power for each state (fep_count, vid_board, clocking)
 # [fep_count, vid_board, clocking, power_avg]

--- a/characteristics.py
+++ b/characteristics.py
@@ -35,10 +35,10 @@ psmc_power = ((0, 0, 0, 43.0),
 # validation limits
 # 'msid' : (( quantile, absolute max value ))
 # Note that the quantile needs to be in the set (1, 5, 16, 50, 84, 95, 99)
-validation_limits = { 'DP_PITCH' : ((1, 5.0),
-                                    (99, 5.0),
-                                    (5, 1.5),
-                                    (95, 1.5),),
+validation_limits = { 'DP_PITCH' : ((1, 7.0),
+                                    (99, 7.0),
+                                    (5, 0.5),
+                                    (95, 0.5),),
                       'POINTING': ((1, .05),
                                  (99, .05),),
                       'ROLL': ((1, .05),


### PR DESCRIPTION
- Expand the 1% and 99% from 5.0 to 7.0.
  These deviations come from maneuvers and there are more maneuvers now.
- Reduce the 5% and 95% from 1.5 to 0.5.
  Normally this runs less than 0.3.